### PR TITLE
Fixes pacifist void jellies

### DIFF
--- a/common/autoloads/effect_queue.gd
+++ b/common/autoloads/effect_queue.gd
@@ -33,6 +33,7 @@ func execute_next(context: Dictionary) -> void:
 	else:
 		effect = queue1.pop_front()
 	if is_instance_valid(effect):
+		# print("Executing effect: ", effect.effect_name)
 		effect.execute(context)
 		return
 	push_error("effect wasn't valid")

--- a/effects/buff_effect/buff_effect.gd
+++ b/effects/buff_effect/buff_effect.gd
@@ -36,9 +36,6 @@ func execute(context: Dictionary) -> void:
 		tween.tween_callback(target.get_buffed.bind(attack_buff).bind(health_buff)).set_delay(FLIGHT_TIME)
 		tween.tween_callback(finish).set_delay(FLIGHT_TIME)
 
-	# Signals for execution to finish in case no valid targets are found
-	super.execute(context)
-
 
 func get_effect_name() -> String:
 	return "BuffEffect"

--- a/effects/buff_effect/buff_effect.gd
+++ b/effects/buff_effect/buff_effect.gd
@@ -36,6 +36,9 @@ func execute(context: Dictionary) -> void:
 		tween.tween_callback(target.get_buffed.bind(attack_buff).bind(health_buff)).set_delay(FLIGHT_TIME)
 		tween.tween_callback(finish).set_delay(FLIGHT_TIME)
 
+	# Signals for execution to finish in case no valid targets are found
+	super.execute(context)
+
 
 func get_effect_name() -> String:
 	return "BuffEffect"

--- a/effects/effect/effect.gd
+++ b/effects/effect/effect.gd
@@ -54,7 +54,7 @@ enum ContextKey {
 
 @export_category("triggers")
 @export var triggers : Array[TriggerType] = []
-var effect_name : String = "Effect"
+@export var effect_name : String = "Effect"
 var error_str : String = ""
 var effect_owner : Hero
 var owner_line_position : int = 0

--- a/heroes/resources/murloc/effects/one_damage.tres
+++ b/heroes/resources/murloc/effects/one_damage.tres
@@ -10,4 +10,5 @@ single_target_types = Array[int]([2])
 include_self = false
 damage = 1
 triggers = Array[int]([5])
+effect_name = "One Damage"
 metadata/_custom_type_script = "uid://fcr77u101a5h"

--- a/heroes/resources/void_jelly/effects/buff_back.tres
+++ b/heroes/resources/void_jelly/effects/buff_back.tres
@@ -10,4 +10,5 @@ include_self = false
 health_buff = 1
 attack_buff = 1
 triggers = Array[int]([1])
+effect_name = "Buff Back"
 metadata/_custom_type_script = "uid://lc8jysx7dkah"

--- a/levels/shop/shop.gd
+++ b/levels/shop/shop.gd
@@ -1,2 +1,5 @@
 class_name Shop
 extends Node2D
+
+@export var purchaseables : Array[Node2D]
+

--- a/levels/shop/shop.tscn
+++ b/levels/shop/shop.tscn
@@ -4,3 +4,8 @@
 
 [node name="Shop" type="Node2D"]
 script = ExtResource("1_sd7uk")
+
+[node name="RerollButton" type="Button" parent="."]
+offset_right = 8.0
+offset_bottom = 8.0
+text = "Reroll Items"


### PR DESCRIPTION
Jellies soft locked trying to use a buff effect without valid targets. Line 16-18 of buff_effect.gd may have been intended to prevent this scenario? If so, call_deferred("finish") didn't work as expected.